### PR TITLE
fix: Node.js version guard for nvm/fnm users

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Talkback requires a **desktop MCP client** — it runs locally on your machine a
 ```
 
 Restart Claude Desktop after saving.
+
+> **Using nvm or fnm?** Claude Desktop doesn't load your shell profile, so it may pick up an old system Node. Use the full path to `npx` instead — run `which npx` in Terminal, then set that as `"command"` in the config above. See [troubleshooting](https://talkback.createwcare.com/docs/troubleshooting) for details.
 </details>
 
 <details>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talkback-mcp",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "MCP server giving AI assistants real-time access to Ableton Live sessions",
   "mcpName": "io.github.jmedure/talkback",
   "repository": {
@@ -10,7 +10,7 @@
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "talkback-mcp": "dist/stdio.js"
+    "talkback-mcp": "dist/check-node.cjs"
   },
   "files": [
     "dist",
@@ -20,7 +20,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "dev:stdio": "tsx src/stdio.ts",
-    "build": "tsc",
+    "build": "tsc && cp scripts/check-node.cjs dist/check-node.cjs",
     "start": "node dist/index.js",
     "start:stdio": "node dist/stdio.js",
     "prepublishOnly": "npm run build",
@@ -38,6 +38,9 @@
     "claude",
     "model-context-protocol"
   ],
+  "engines": {
+    "node": ">=18"
+  },
   "license": "PolyForm-Shield-1.0.0",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",

--- a/scripts/check-node.cjs
+++ b/scripts/check-node.cjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+"use strict";
+
+// This file MUST use only syntax compatible with Node.js v0.12+
+// so it can print a helpful error on ancient Node versions.
+// It exists because Claude Desktop (and similar launchers) do not
+// source shell profiles, so nvm/fnm users may resolve an old
+// system Node that cannot parse the ESM entry point (stdio.js).
+
+var major = parseInt(process.versions.node.split(".")[0], 10);
+
+if (major < 18) {
+  process.stderr.write(
+    "\n" +
+      "ERROR: talkback-mcp requires Node.js 18 or later.\n" +
+      "You are running Node.js " +
+      process.version +
+      ".\n\n" +
+      "This commonly happens with Claude Desktop because it does not\n" +
+      "source your shell profile (~/.zshrc, ~/.bashrc), so nvm/fnm\n" +
+      "are not initialized and an old system Node is used instead.\n\n" +
+      "To fix this, use the full path to npx in your MCP client config.\n" +
+      "Run `which npx` in Terminal to find your path, then update:\n\n" +
+      '  "command": "/Users/YOU/.nvm/versions/node/v22.x.x/bin/npx"\n\n' +
+      "See: https://talkback.dev/docs/troubleshooting\n\n"
+  );
+  process.exit(1);
+}
+
+// Node is new enough — hand off to the real ESM entry point.
+import("./stdio.js").catch(function (err) {
+  process.stderr.write("Failed to load talkback-mcp: " + err.message + "\n");
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds a CJS launcher (`check-node.cjs`) as the new bin entry point that checks Node >= 18 before loading the ESM entry point — users with nvm/fnm on Claude Desktop now get a clear, actionable error instead of cryptic `SyntaxError` or `ERROR: You must supply a command`
- Adds `engines` field to `package.json` so npm warns on install if Node is too old
- Adds nvm/fnm callout to README

## Test plan

- [x] `npm run build` succeeds — `dist/check-node.cjs` is copied from `scripts/`
- [x] `node dist/check-node.cjs` with Node 18+ starts the server normally (WebSocket bridge + stdio transport confirmed)
- [x] Version guard logic confirmed: prints clear error for Node < 18
- [x] `npm link` → `talkback-mcp` resolves to `dist/check-node.cjs`
- [ ] After merge: verify `npx -y talkback-mcp` picks up v0.1.8 from npm

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)